### PR TITLE
_sctp.c - flags should be 0

### DIFF
--- a/_sctp.c
+++ b/_sctp.c
@@ -1558,7 +1558,7 @@ static PyObject* sctp_recv_msg(PyObject* dummy, PyObject* args)
 	char cfrom[256];
 	char *msg;
 	int size;
-	int flags;
+	int flags = 0;		// Must be 0 due to bug in older systems
 	struct sctp_sndrcvinfo sinfo;
 
 	PyObject* notification = PyDict_New();


### PR DESCRIPTION
The function sctp_recvmsg do not block as it should.

Found this:
lakerest.net/pipermail/sctp-coders/2008-April/006112.html

   " The msg_flags needs to be initialized. Its an in-out parameter and
   thus its looked at. I have no idea what is in the msg_flags field when
   you call it...

   The missing init in UNP is my oversight combined with a bug
   that was fixed in FreeBSD about a year ago (ie. it ignored msg_flags
   on input).
   "

This is apparently true on older Linux systems as well. Same code?
