### PR TITLE
Use socket adaptation (~ppid) option as default adaptation value

### DIFF
--- a/sctp.py
+++ b/sctp.py
@@ -1112,7 +1112,7 @@ class sctpsocket(object):
 
 		return _sctp.getladdrs(self._sk.fileno(), assoc_id)
 
-	def sctp_send(self, msg, to=("",0), ppid=0, flags=0, stream=None, timetolive=None, context=0,
+	def sctp_send(self, msg, to=("",0), ppid=None, flags=0, stream=None, timetolive=None, context=0,
 	                    record_file_prefix="RECORD_sctp_traffic", datalogging = False):
 		"""
 		Sends a SCTP message. While send()/sendto() can also be used, this method also
@@ -1156,6 +1156,9 @@ class sctpsocket(object):
 		both by the implementation and by the transmission buffer (SO_SNDBUF).
 		The application must configure this buffer accordingly.
 		"""
+
+		if ppid is None:
+			ppid = self.adaptation
 
 		if timetolive is None:
 			timetolive = self._ttl


### PR DESCRIPTION
 Current SCTP linux release A1305EABD8F6C3D37020C43 break the behaviour of
 previous release AE81E0A508A0D11D1341E64

 In AE81E0A508A0D11D1341E64 when setting the socket option
` SCTP_ADAPTATION_LAYER`, it was then use as global default value for
 next assosiations.

 It is not the case anymore in A1305EABD8F6C3D37020C43.
 That commit shield us against that breaking change.