### PR TITLE
Fix / sctp_send: add support of bytearray

### DIFF
--- a/sctp.py
+++ b/sctp.py
@@ -1175,7 +1175,7 @@ class sctpsocket(object):
 			recordlog = open(recordfilename+"%d"%i, 'w')
 			recordlog.write(msg)
 			recordlog.close()
-		return _sctp.sctp_send_msg(self._sk.fileno(), msg, to, ppid, flags, stream, timetolive, context)
+		return _sctp.sctp_send_msg(self._sk.fileno(), bytes(msg), to, ppid, flags, stream, timetolive, context)
 
 	def sctp_recv(self, maxlen):
 		"""


### PR DESCRIPTION
Hi, 

Actually, the wrapper arround `_sctp.sctp_send_msg` only accept readonly `bytes`. 

On my side I'm using python [asyncio from an existing sctp socket](https://github.com/python/cpython/blob/f4c03484da59049eb62a9bf7777b963e2267d187/Doc/library/asyncio-protocol.rst#connecting-existing-sockets). The library will time to time call the socket send method with a mutable `bytearray` instead of an immutable `bytes` as parameter, which will trigger an error:

```
  File "/usr/local/lib/python3.10/dist-packages/pysctp-0.7.1-py3.10-linux-x86_64.egg/sctp.py", line 1178, in sctp_send
    return _sctp.sctp_send_msg(self._sk.fileno(), msg, to, ppid, flags, stream, timetolive, context)
TypeError: argument 2 must be read-only bytes-like object, not bytearray
```

It's seems common for python to accept either a bytearray or bytes and looks to not ~fully be a bug on asyncio side, python socket.py write's method description says:
```
        """Write the given bytes or bytearray object *b* to the socket
        and return the number of bytes written.  This can be less than
        len(b) if not all data could be written.  If the socket is
        non-blocking and no bytes could be written None is returned.
        """
```

Proposed fix here, always enforce the conversion to read only `bytes`