### PR TITLE
Building, testing and publishing wheels via GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
            CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
            CIBW_BEFORE_ALL_LINUX: >
              sed -i 's/exclude=.gov, facebook/exclude=.gov, facebook, mirror.es.its.nyu.edu/' /etc/yum/pluginconf.d/fastestmirror.conf &&
-             rm /var/cache/yum/timedhosts.txt &&
+             rm -f /var/cache/yum/timedhosts.txt &&
              yum install -y lksctp-tools-dev
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-           CIBW_BEFORE_ALL: ./build_dependencies.sh
+           CIBW_BEFORE_ALL: apt-get update && apt-get install -y libpython3-dev libsctp-dev gcc make
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
              rm -f /var/cache/yum/timedhosts.txt &&
              yum install -y lksctp-tools-devel
            #for now just a quick test of loopback
-           CIBW_TEST_COMMAND: python3 test_loopback.py
+           CIBW_TEST_COMMAND: python3 {project}/test_loopback.py
            #skipping PyPy and musllinux builds
            CIBW_SKIP: pp* "*-musllinux*"
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,12 +19,10 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.10.2
 
-      - name: Install requirements
-        run: sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make
-
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+           CIBW_BEFORE_ALL: sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-           CIBW_BEFORE_ALL: sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make
+           CIBW_BEFORE_ALL: ./build_dependencies.sh
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,6 +55,7 @@ jobs:
       - name: download artifact
         uses: actions/download-artifact@v3
         with:
+          name: artifact
           path: dist/
       - name: publish built artifacts to test.pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,6 +23,10 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
            #CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get install -y libpython3-dev libsctp-dev gcc make
+           # Build using the latest manylinux2014 release, instead of the cibuildwheel
+           # pinned version
+           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
            CIBW_BEFORE_ALL_LINUX: yum install -y lksctp-tools-dev
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-           CIBW_BEFORE_ALL: apt-get update && apt-get install -y libpython3-dev libsctp-dev gcc make
+           #CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get install -y libpython3-dev libsctp-dev gcc make
+           CIBW_BEFORE_ALL_LINUX: yum install -y lksctp-tools-dev
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 {project}/test_loopback.py
            #skipping PyPy and musllinux builds
-           CIBW_SKIP: pp* "*-musllinux*"
+           CIBW_SKIP: "pp* *musllinux*"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,10 @@ jobs:
            # pinned version
            CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
            CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-           CIBW_BEFORE_ALL_LINUX: YUM0=mirror.centos.org yum install -y lksctp-tools-dev
+           CIBW_BEFORE_ALL_LINUX: >
+             sed -i 's/exclude=.gov, facebook/exclude=.gov, facebook, mirror.es.its.nyu.edu/' fastestmirror.conf &&
+             rm /var/cache/yum/timedhosts.txt &&
+             yum install -y lksctp-tools-dev
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
            #skipping PyPy and musllinux builds

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
            CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
            CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
            CIBW_BEFORE_ALL_LINUX: >
-             sed -i 's/exclude=.gov, facebook/exclude=.gov, facebook, mirror.es.its.nyu.edu/' /etc/yum/pluginconf.d/fastestmirror.conf &&
+             echo "exclude=mirror.es.its.nyu.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf &&
              rm -f /var/cache/yum/timedhosts.txt &&
              yum install -y lksctp-tools-dev
            #for now just a quick test of loopback

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
            CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
            CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
            CIBW_BEFORE_ALL_LINUX: >
-             sed -i 's/exclude=.gov, facebook/exclude=.gov, facebook, mirror.es.its.nyu.edu/' fastestmirror.conf &&
+             sed -i 's/exclude=.gov, facebook/exclude=.gov, facebook, mirror.es.its.nyu.edu/' /etc/yum/pluginconf.d/fastestmirror.conf &&
              rm /var/cache/yum/timedhosts.txt &&
              yum install -y lksctp-tools-dev
            #for now just a quick test of loopback

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,15 +22,7 @@ jobs:
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-           #CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get install -y libpython3-dev libsctp-dev gcc make
-           # Build using the latest manylinux2014 release, instead of the cibuildwheel
-           # pinned version
-           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-           CIBW_BEFORE_ALL_LINUX: >
-             echo "exclude=mirror.es.its.nyu.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf &&
-             rm -f /var/cache/yum/timedhosts.txt &&
-             yum install -y lksctp-tools-devel
+           CIBW_BEFORE_ALL_LINUX: yum install -y lksctp-tools-devel
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 {project}/test_loopback.py
            #skipping PyPy and musllinux builds

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,8 +16,8 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.10.2
+      - name: Install cibuildwheel & build
+        run: python -m pip install cibuildwheel==2.10.2 build
 
       - name: Build wheels & test
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -35,6 +35,12 @@ jobs:
            CIBW_TEST_COMMAND: python3 {project}/test_loopback.py
            #skipping PyPy and musllinux builds
            CIBW_SKIP: "pp* *musllinux*"
+
+      - name: Build sdist
+        run: python -m build --sdist -o wheelhouse
+
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: |
+            ./wheelhouse/*.whl
+            ./wheelhouse/*.tar.gz

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
            CIBW_BEFORE_ALL_LINUX: >
              echo "exclude=mirror.es.its.nyu.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf &&
              rm -f /var/cache/yum/timedhosts.txt &&
-             yum install -y lksctp-tools-dev
+             yum install -y lksctp-tools-devel
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
            #skipping PyPy and musllinux builds

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,14 +1,14 @@
-name: Build
+name: Build, test wheels & Publish
 
 on: [push, pull_request]
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+  build_test_wheels:
+    name: Build & test wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -44,3 +44,28 @@ jobs:
           path: |
             ./wheelhouse/*.whl
             ./wheelhouse/*.tar.gz
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    needs:
+      - build_test_wheels
+    steps:
+      - name: setup python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v4
+      - name: download artifact
+        uses: actions/download-artifact@v3
+        with:
+          path: dist/
+      - name: publish built artifacts to test.pypi.org
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+      - name: publish built artifacts to pypi.org
+        if: ${{ startsWith(github.ref, 'refs/tag') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,10 +27,11 @@ jobs:
            # pinned version
            CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
            CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-           CIBW_BEFORE_ALL_LINUX: yum install -y lksctp-tools-dev
+           CIBW_BEFORE_ALL_LINUX: YUM0=mirror.centos.org yum install -y lksctp-tools-dev
            #for now just a quick test of loopback
            CIBW_TEST_COMMAND: python3 test_loopback.py
-
+           #skipping PyPy and musllinux builds
+           CIBW_SKIP: pp* "*-musllinux*"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.10.2
+
+      - name: Install requirements
+        run: sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make
+
+      - name: Build wheels & test
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+           #for now just a quick test of loopback
+           CIBW_TEST_COMMAND: python3 test_loopback.py
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo apt-get update && sudo apt-get install -y libpython3-dev libsctp-dev gcc make


### PR DESCRIPTION
This CI/CD config file allows building, testing and publishing wheels of pysctp. It is limited intentionally to only create ```x86_64``` and ```i686``` builds for CPython 3.6-3.11 for ```manylinux``` architecture. Any of these limitations could be lifted by editing the ```wheels.yml``` file, and especially changing the ```CIBW_SKIP``` variable.
The ```publish``` job was taken almost directly as-is from ```pycrate```.

EDIT: Naturally for this to be fully functional secrets/tokens for Pypi must be added the same way they are already added to the ```pycrate``` project. Also I guess an official tag with ```0.7.2``` not just the change in ```VERSION``` would make things complete after potential merge :)